### PR TITLE
Update createIndex calls to use collection

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -120,11 +120,11 @@ class Database {
   // יצירת אינדקסים לביצועים טובים יותר
   async createIndexes() {
     try {
-      await Query.createIndex({ chatId: 1, timestamp: -1 });
-      await Query.createIndex({ 'deviceInfo.manufacturerKey': 1, 'deviceInfo.deviceKey': 1 });
-      await UpdateTracking.createIndex({ manufacturerKey: 1, deviceKey: 1, version: 1 });
-      await SystemStats.createIndex({ date: -1 });
-      await Feedback.createIndex({ chatId: 1, timestamp: -1 });
+      await Query.collection.createIndex({ chatId: 1, timestamp: -1 });
+      await Query.collection.createIndex({ 'deviceInfo.manufacturerKey': 1, 'deviceInfo.deviceKey': 1 });
+      await UpdateTracking.collection.createIndex({ manufacturerKey: 1, deviceKey: 1, version: 1 });
+      await SystemStats.collection.createIndex({ date: -1 });
+      await Feedback.collection.createIndex({ chatId: 1, timestamp: -1 });
     } catch (error) {
       console.error('Error creating indexes:', error);
     }


### PR DESCRIPTION
Update Mongoose `createIndex` calls to use `Model.collection.createIndex` because `createIndex` is available on the `collection` object, not directly on the `Model`.

---

[Open in Web](https://cursor.com/agents?id=bc-876b8322-72fc-4939-a5db-a1e508d09f5d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-876b8322-72fc-4939-a5db-a1e508d09f5d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)