### PR TITLE
Replace claude-sonnet-4-20250514 model everywhere

### DIFF
--- a/src/updateChecker.js
+++ b/src/updateChecker.js
@@ -283,7 +283,7 @@ class UpdateChecker {
           'anthropic-version': '2023-06-01'
         },
         body: JSON.stringify({
-          model: 'claude-3-opus-20240229',
+          model: 'claude-sonnet-4-20250514',
           max_tokens: 1000,
           messages: [
             { role: 'user', content: prompt }


### PR DESCRIPTION
Update the Claude model from `claude-3-opus-20240229` to `claude-sonnet-4-20250514` as requested by the user.

---

[Open in Web](https://cursor.com/agents?id=bc-5d68afba-5a74-45c6-b03c-62427aab42a3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5d68afba-5a74-45c6-b03c-62427aab42a3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)