### PR TITLE
Prevent scheduler from running on cron jobs

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -85,12 +85,12 @@ cronJobs:
   - name: daily-cleanup
     schedule: "0 2 * * *"
     buildCommand: npm install
-    startCommand: node -e "require('./src/scheduler').runTaskNow('daily')"
+    startCommand: RUN_TASK_NOW=true node -e "require('./src/scheduler').runTaskNow('daily')"
     
   - name: weekly-maintenance
     schedule: "0 3 * * 0"
     buildCommand: npm install
-    startCommand: node -e "require('./src/scheduler').runTaskNow('weekly')"
+    startCommand: RUN_TASK_NOW=true node -e "require('./src/scheduler').runTaskNow('weekly')"
 
 # הגדרות environment variables גלובליות
 envVarGroups:

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -351,22 +351,27 @@ class Scheduler {
 // יצירת מופע יחיד ולהפעילו
 const scheduler = new Scheduler();
 
-// הפעלה אוטומטית כשהמודול נטען
-if (process.env.NODE_ENV !== 'test') {
+// הפעלה אוטומטית רק אם לא קוראים ישירות ל-runTaskNow ע"י פקודת cron
+if (
+  process.env.NODE_ENV !== 'test' &&
+  process.env.RUN_TASK_NOW !== 'true'
+) {
   scheduler.start();
 }
 
-// טיפול בסגירה נאותה
-process.on('SIGINT', () => {
-  console.log('\n🛑 Received SIGINT, stopping scheduler...');
-  scheduler.stop();
-  process.exit(0);
-});
+// טיפול בסגירה נאותה - רק אם הסקדג'ולר פועל
+if (process.env.RUN_TASK_NOW !== 'true') {
+  process.on('SIGINT', () => {
+    console.log('\n🛑 Received SIGINT, stopping scheduler...');
+    scheduler.stop();
+    process.exit(0);
+  });
 
-process.on('SIGTERM', () => {
-  console.log('\n🛑 Received SIGTERM, stopping scheduler...');
-  scheduler.stop();
-  process.exit(0);
-});
+  process.on('SIGTERM', () => {
+    console.log('\n🛑 Received SIGTERM, stopping scheduler...');
+    scheduler.stop();
+    process.exit(0);
+  });
+}
 
 module.exports = scheduler;


### PR DESCRIPTION
Ensure the main scheduler runs only with the primary application, not during cron job executions.

This prevents the main scheduler from starting and registering signal handlers when `RUN_TASK_NOW` is true, ensuring that cron jobs execute only their specific tasks without unnecessary overhead, duplicate scheduled tasks, or signal listener registrations.

---

[Open in Web](https://cursor.com/agents?id=bc-cf3177c8-8668-444d-a00f-e85155b089cf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cf3177c8-8668-444d-a00f-e85155b089cf) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)