### PR TITLE
Continue and split user reports

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -432,7 +432,7 @@ function formatUserReports(searchResults) {
         reports += `  <b>דיווחי משתמשים:</b>\n`;
         discussion.userReports.slice(0, 10).forEach(userReport => {
           const sentimentEmoji = getSentimentEmoji(userReport.sentiment);
-          reports += `    ${sentimentEmoji} <i>"${truncateText(userReport.content, 100)}"</i>\n`;
+          reports += `    ${sentimentEmoji} <i>"${userReport.content}"</i>\n`;
           reports += `    👤 ${userReport.author} | ${timeAgo(userReport.date)}\n`;
         });
       }
@@ -603,7 +603,7 @@ function formatForumReports(forumDiscussions) {
       reports += `  <b>דיווחי משתמשים:</b>\n`;
       discussion.userReports.slice(0, 8).forEach(userReport => { // מגביל ל-8 דיווחים פנימיים
         const sentimentEmoji = getSentimentEmoji(userReport.sentiment);
-        reports += `    ${sentimentEmoji} <i>"${truncateText(userReport.content, 80)}"</i>\n`;
+        reports += `    ${sentimentEmoji} <i>"${userReport.content}"</i>\n`;
       });
     }
     


### PR DESCRIPTION
Display full user reports by removing text truncation to prevent content from being cut off.

---

[Open in Web](https://cursor.com/agents?id=bc-1d5325d3-9ee8-448d-9038-5feadc3a3389) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1d5325d3-9ee8-448d-9038-5feadc3a3389) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)