### PR TITLE
Process forum user reports for android 15

### DIFF
--- a/common/updateChecker.js
+++ b/common/updateChecker.js
@@ -372,36 +372,42 @@ class UpdateChecker {
         {
           name: 'Android Police',
           domain: 'androidpolice.com',
-          weight: 0.8
+          weight: 0.8,
+          description: 'ביקורות מקצועיות ומדריכים מפורטים'
         },
         {
           name: 'Android Authority', 
           domain: 'androidauthority.com',
-          weight: 0.8
+          weight: 0.8,
+          description: 'ניתוחים טכניים ובדיקות ביצועים'
         },
         {
           name: '9to5Google',
           domain: '9to5google.com', 
-          weight: 0.7
+          weight: 0.7,
+          description: 'חדשות ועדכונים מהירים'
         }
       ];
 
-      for (const site of techSites) {
+      // הגבלה למקסימום 2 אתרים כדי למנוע חזרות מיותרות
+      const selectedSites = techSites.slice(0, 2);
+
+      for (const site of selectedSites) {
         try {
           const siteSearchUrl = `https://www.google.com/search?q=site:${site.domain}+${encodeURIComponent(searchQuery)}`;
           
           // הוספת תוצאה עם קישור לחיפוש באתר
           results.push({
-            title: `${deviceInfo.device} ${parsedQuery.version} - ${site.name} Coverage`,
+            title: `${deviceInfo.device} ${parsedQuery.version} - ${site.name}`,
             url: `https://${site.domain}/search?q=${encodeURIComponent(searchQuery)}`,
             source: site.name,
             weight: site.weight,
-            summary: `חיפוש ב-${site.name} עבור מידע על העדכון`,
+            summary: `${site.description} - חיפוש עבור ${deviceInfo.device}`,
             date: new Date(),
             sentiment: 'neutral',
             userReports: [{
               author: `${site.name} Editorial`,
-              content: `מאמרים וביקורות על עדכון ${parsedQuery.version} עבור ${deviceInfo.device}`,
+              content: `${site.description} על עדכון ${parsedQuery.version}`,
               sentiment: 'neutral',
               date: new Date()
             }]


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Reduce repetitive and generic content in user reports to improve clarity and relevance.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses user feedback regarding excessive repetition and lack of meaningful content in the "User Reports" section. Changes include:
- Limiting the number of tech news sources and providing unique descriptions to avoid generic summaries.
- Enhancing report filtering and deduplication logic to ensure only meaningful and unique user discussions are displayed, filtering out generic or very short content.
- Reducing the maximum number of displayed report sections and discussions to prevent information overload.

---

[Open in Web](https://cursor.com/agents?id=bc-5d876e2c-c813-4fb2-afa0-190263d71b40) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5d876e2c-c813-4fb2-afa0-190263d71b40) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)