### PR TITLE
Fix bot message splitting error

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -535,7 +535,13 @@ ${usageEmoji} **שאילתות החודש:**
           console.log('❓ Processing general question');
           
           const generalInfo = await updateChecker.searchGeneralInfo(messageText);
-          response = generalInfo || 'מצטער, לא מצאתי מידע רלוונטי לשאלה שלכם. אנא נסו לנסח אחרת או שלחו פרטי מכשיר ספציפיים.';
+          
+          // בדיקה אם החיפוש הצליח וחילוץ התוכן המתאים
+          if (generalInfo && generalInfo.success && generalInfo.data) {
+            response = generalInfo.data.summary || generalInfo.message || 'מצאתי מידע כללי על השאילתה שלכם.';
+          } else {
+            response = generalInfo?.message || 'מצטער, לא מצאתי מידע רלוונטי לשאלה שלכם. אנא נסו לנסח אחרת או שלחו פרטי מכשיר ספציפיים.';
+          }
           
           // רישום האינטראקציה
           await Database.logUserInteraction(chatId, 'question', {

--- a/common/utils.js
+++ b/common/utils.js
@@ -489,6 +489,12 @@ function getSentimentEmoji(sentiment) {
 const TELEGRAM_MESSAGE_LIMIT = 4096; // מגבלת טלגרם
 
 function splitLongMessage(message) {
+  // וידוא שההודעה היא מחרוזת
+  if (typeof message !== 'string') {
+    console.error('splitLongMessage received non-string message:', typeof message, message);
+    message = String(message || 'שגיאה בפיצול ההודעה');
+  }
+  
   if (message.length <= TELEGRAM_MESSAGE_LIMIT) {
     return [message];
   }
@@ -761,6 +767,12 @@ function formatResponseWithUserReports(deviceInfo, updateInfo, recommendation) {
 // פונקציה לפיצול הודעות רגילות (עבור תאימות לאחור)
 function formatResponseWithSplit(response) {
   const TELEGRAM_LIMIT = 4096;
+  
+  // וידוא שהתגובה היא מחרוזת
+  if (typeof response !== 'string') {
+    console.error('formatResponseWithSplit received non-string response:', typeof response, response);
+    response = String(response || 'שגיאה בעיצוב התגובה');
+  }
   
   if (response.length <= TELEGRAM_LIMIT) {
     return {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `message.split is not a function` error by correctly handling `searchGeneralInfo` object response and adding type validation to utility functions.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `searchGeneralInfo` function returned an object, but the bot's response handling directly assigned this object as a string. This led to `message.split is not a function` errors when subsequent utility functions attempted string operations on the object. The fix extracts the correct string data from the `searchGeneralInfo` result and adds type checks to `splitLongMessage` and `formatResponseWithSplit` for robustness.

---

[Open in Web](https://cursor.com/agents?id=bc-41dc57f9-dbb0-44bb-b45a-c3dfca27d506) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-41dc57f9-dbb0-44bb-b45a-c3dfca27d506) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)