### PR TITLE
Fix bot search results across multiple sites

### DIFF
--- a/GOOGLE_CSE_FIX_GUIDE.md
+++ b/GOOGLE_CSE_FIX_GUIDE.md
@@ -1,0 +1,127 @@
+# מדריך תיקון Google Custom Search Engine
+
+## 🎯 המטרה
+לתקן את ה-Custom Search Engine כך שיחפש בכל האתרים הרצויים ולא רק ברדיט.
+
+## 🔍 בדיקת הבעיה הנוכחית
+
+הבעיה: הבוט מחזיר תוצאות רק מרדיט למרות שמוגדרים 6 אתרים.
+
+**האתרים שצריכים להיות מוגדרים:**
+1. reddit.com
+2. xda-developers.com
+3. androidcentral.com
+4. androidpolice.com
+5. 9to5google.com
+6. support.google.com
+
+## 🛠️ שלבי התיקון
+
+### שלב 1: כניסה ל-Google Custom Search Console
+
+1. היכנס ל: https://programmablesearchengine.google.com/controlpanel
+2. התחבר עם החשבון Google שלך
+3. בחר את ה-Search Engine שלך מהרשימה
+4. לחץ על **"Control Panel"**
+
+### שלב 2: בדיקת האתרים הנוכחיים
+
+1. לך לטאב **"Basics"**
+2. גלול למטה ל-**"Sites to search"**
+3. בדוק מה רשום שם כרגע
+
+### שלב 3: ניקוי והגדרה מחדש
+
+1. **מחק את כל האתרים הקיימים:**
+   - לחץ על ה-X ליד כל אתר קיים
+   - שמור את השינויים
+
+2. **הוסף את האתרים הנכונים:**
+   לחץ על **"Add"** והוסף את האתרים הבאים **בדיוק כך**:
+   ```
+   reddit.com/*
+   xda-developers.com/*
+   androidcentral.com/*
+   androidpolice.com/*
+   9to5google.com/*
+   support.google.com/*
+   ```
+
+### שלב 4: הגדרות נוספות חשובות
+
+1. **Search features:**
+   - ודא ש-**"Search the entire web"** מכובה (OFF)
+   - זה חשוב! אם זה דלוק, זה יכול לגרום לתוצאות לא רצויות
+
+2. **Sites to exclude:**
+   - ודא שהרשימה ריקה
+   - אם יש שם משהו, מחק הכל
+
+### שלב 5: בדיקת התצורה
+
+1. לך לטאב **"Preview"**
+2. נסה חיפוש של: `Android 14 update`
+3. בדוק שמגיעות תוצאות מכמה אתרים שונים
+
+## 🔧 הגדרות מתקדמות (אופציונלי)
+
+### אם עדיין יש בעיות:
+
+1. **יצירת CSE חדש:**
+   - לחץ על "Create a custom search engine"
+   - הוסף את כל 6 האתרים מההתחלה
+   - העתק את ה-Search Engine ID החדש
+
+2. **עדכון משתני הסביבה ברנדר:**
+   - עדכן את `GOOGLE_SEARCH_ENGINE_ID` עם ה-ID החדש
+
+## 📊 בדיקת התוצאות
+
+אחרי התיקון, הבוט צריך להחזיר תוצאות כך:
+- reddit.com: ~20-30% מהתוצאות
+- xda-developers.com: ~15-20%
+- androidcentral.com: ~15-20%
+- androidpolice.com: ~10-15%
+- 9to5google.com: ~10-15%
+- support.google.com: ~5-10%
+
+## 🚨 בעיות נפוצות ופתרונות
+
+### בעיה: עדיין רק תוצאות מרדיט
+**פתרון:** ודא שלא הוספת `www.` לפני שמות האתרים
+
+### בעיה: אין תוצאות בכלל
+**פתרון:** 
+1. בדוק שה-API Key תקין
+2. בדוק שה-Search Engine ID נכון
+3. ודא שלא חרגת מהמכסה היומית
+
+### בעיה: תוצאות מאתרים לא רצויים
+**פתרון:** ודא ש-"Search the entire web" מכובה
+
+## 📝 לוג בדיקה
+
+כשתעשה את השינויים, תוכל לבדוק בלוגים של הבוט:
+```
+🔍 Searching reddit.com for: "Android 14"
+📝 Full query: "Android 14 site:reddit.com"
+✅ Found 8 results from reddit.com
+
+🔍 Searching xda-developers.com for: "Android 14"  
+📝 Full query: "Android 14 site:xda-developers.com"
+✅ Found 6 results from xda-developers.com
+```
+
+אם אתה רואה רק reddit.com בלוגים, זה אומר שהבעיה עדיין קיימת.
+
+## 🎯 המטרה הסופית
+
+אחרי התיקון, כשמישהו ישאל "מה דעתכם על אנדרואיד 14?", הבוט יחזיר:
+- ביקורות מ-AndroidCentral
+- דיונים מ-Reddit  
+- מדריכים מ-XDA Developers
+- חדשות מ-AndroidPolice
+- מאמרים מ-9to5Google
+- תמיכה רשמית מ-Google Support
+
+זה יתן תמונה מקיפה הרבה יותר!

--- a/services/googleSearch.js
+++ b/services/googleSearch.js
@@ -81,6 +81,8 @@ async function searchSpecificSite(query, site, maxResults = 10) {
  */
 async function searchAllSitesBalanced(query, resultsPerSite = 8) {
     console.log(`🚀 Starting balanced search across ${TARGET_SITES.length} sites...`);
+    console.log(`📝 Query: "${query}"`);
+    console.log(`🎯 Target sites: ${TARGET_SITES.join(', ')}`);
     
     // חיפוש מקביל בכל האתרים עם site: operator
     const siteSearchPromises = TARGET_SITES.map(site => 
@@ -105,7 +107,7 @@ async function searchAllSitesBalanced(query, resultsPerSite = 8) {
             });
         });
         
-        // סטטיסטיקות
+        // סטטיסטיקות מפורטות
         const siteDistribution = {};
         allResults.forEach(item => {
             siteDistribution[item.sourceSite] = (siteDistribution[item.sourceSite] || 0) + 1;
@@ -115,6 +117,16 @@ async function searchAllSitesBalanced(query, resultsPerSite = 8) {
         Object.entries(siteDistribution).forEach(([site, count]) => {
             console.log(`   ${site}: ${count} results`);
         });
+        
+        // אזהרות אם יש בעיות
+        const sitesWithResults = Object.keys(siteDistribution).length;
+        if (sitesWithResults === 1 && siteDistribution['reddit.com']) {
+            console.log('🚨 WARNING: Only Reddit results found! Check CSE configuration.');
+        } else if (sitesWithResults < TARGET_SITES.length / 2) {
+            console.log(`⚠️  WARNING: Only ${sitesWithResults}/${TARGET_SITES.length} sites returned results.`);
+        } else {
+            console.log(`✅ Good distribution: ${sitesWithResults}/${TARGET_SITES.length} sites have results.`);
+        }
         
         return allResults;
         

--- a/services/googleSearch.js
+++ b/services/googleSearch.js
@@ -9,6 +9,16 @@ if (!GOOGLE_API_KEY || !GOOGLE_CSE_ID) {
 
 const googleApiUrl = 'https://www.googleapis.com/customsearch/v1';
 
+// האתרים המוגדרים במנוע החיפוש המותאם אישית
+const TARGET_SITES = [
+    'reddit.com',
+    'xda-developers.com', 
+    'androidcentral.com',
+    'androidpolice.com',
+    '9to5google.com',
+    'support.google.com'
+];
+
 function extractModelFromQuery(query) {
     const lowerCaseQuery = query.toLowerCase();
     const words = lowerCaseQuery.split(' ');
@@ -17,91 +27,168 @@ function extractModelFromQuery(query) {
 }
 
 /**
- * Fetches up to 100 results with enhanced search queries and performs intelligent filtering.
+ * חיפוש באתר ספציפי
+ */
+async function searchSpecificSite(query, site, maxResults = 15) {
+    const siteQuery = `${query} site:${site}`;
+    
+    try {
+        console.log(`🔍 Searching ${site} for: "${query}"`);
+        
+        const response = await axios.get(googleApiUrl, {
+            params: { 
+                key: GOOGLE_API_KEY, 
+                cx: GOOGLE_CSE_ID, 
+                q: siteQuery, 
+                num: Math.min(maxResults, 10),
+                dateRestrict: 'm6',
+                lr: 'lang_en' 
+            }
+        });
+
+        const items = response.data.items || [];
+        console.log(`✅ Found ${items.length} results from ${site}`);
+        
+        return items.map(item => ({
+            ...item,
+            sourceSite: site
+        }));
+        
+    } catch (error) {
+        console.warn(`⚠️ Search failed for ${site}:`, error.message);
+        return [];
+    }
+}
+
+/**
+ * חיפוש מאוזן בכל האתרים
+ */
+async function searchAllSitesBalanced(query, resultsPerSite = 15) {
+    console.log(`🚀 Starting balanced search across ${TARGET_SITES.length} sites...`);
+    
+    // חיפוש מקביל בכל האתרים
+    const siteSearchPromises = TARGET_SITES.map(site => 
+        searchSpecificSite(query, site, resultsPerSite)
+    );
+    
+    try {
+        const siteResults = await Promise.all(siteSearchPromises);
+        let allResults = [];
+        let uniqueLinks = new Set();
+        
+        // איסוף תוצאות מכל האתרים
+        siteResults.forEach((results, index) => {
+            const site = TARGET_SITES[index];
+            console.log(`📊 ${site}: ${results.length} results`);
+            
+            results.forEach(item => {
+                if (!uniqueLinks.has(item.link)) {
+                    uniqueLinks.add(item.link);
+                    allResults.push(item);
+                }
+            });
+        });
+        
+        // סטטיסטיקות
+        const siteDistribution = {};
+        allResults.forEach(item => {
+            siteDistribution[item.sourceSite] = (siteDistribution[item.sourceSite] || 0) + 1;
+        });
+        
+        console.log('📈 Results distribution by site:');
+        Object.entries(siteDistribution).forEach(([site, count]) => {
+            console.log(`   ${site}: ${count} results`);
+        });
+        
+        return allResults;
+        
+    } catch (error) {
+        console.error('❌ Error in balanced site search:', error.message);
+        return [];
+    }
+}
+
+/**
+ * חיפוש היברידי - מאוזן + כללי
+ */
+async function hybridSearch(query) {
+    console.log(`🔄 Starting hybrid search strategy...`);
+    
+    // 1. חיפוש מאוזן באתרים ספציפיים (עד 15 מכל אתר = 90 תוצאות)
+    const balancedResults = await searchAllSitesBalanced(query, 15);
+    
+    // 2. חיפוש כללי נוסף (אם יש מעט תוצאות)
+    let generalResults = [];
+    if (balancedResults.length < 60) {
+        console.log(`🔍 Adding general search to supplement results...`);
+        
+        try {
+            const response = await axios.get(googleApiUrl, {
+                params: { 
+                    key: GOOGLE_API_KEY, 
+                    cx: GOOGLE_CSE_ID, 
+                    q: `${query} review experience feedback`,
+                    num: 10,
+                    dateRestrict: 'm6',
+                    lr: 'lang_en' 
+                }
+            });
+            
+            generalResults = (response.data.items || []).map(item => ({
+                ...item,
+                sourceSite: 'general'
+            }));
+            
+        } catch (error) {
+            console.warn('⚠️ General search failed:', error.message);
+        }
+    }
+    
+    // 3. איחוד התוצאות
+    let allResults = [...balancedResults];
+    let uniqueLinks = new Set(balancedResults.map(item => item.link));
+    
+    generalResults.forEach(item => {
+        if (!uniqueLinks.has(item.link)) {
+            uniqueLinks.add(item.link);
+            allResults.push(item);
+        }
+    });
+    
+    console.log(`✅ Total unique results: ${allResults.length}`);
+    
+    return allResults;
+}
+
+/**
+ * Fetches results using a balanced approach across multiple sites
  * @param {string} userQuery - The user's query.
- * @returns {Promise<Array<object>>} A comprehensive, well-filtered list of relevant search results.
+ * @returns {Promise<Array<object>>} A balanced list of search results from multiple sources.
  */
 async function searchGoogle(userQuery) {
     const englishQuery = userQuery.replace(/אנדרואיד/g, 'Android').replace(/\?/g, '');
     
-    // שליחת מספר חיפושים מקבילים עם מילות מפתח שונות לכיסוי מקיף יותר
-    const searchQueries = [
-        `${englishQuery} review feedback experience user reports`,
-        `${englishQuery} update problems issues bugs battery performance`,
-        `${englishQuery} after update thoughts opinions reddit forum`,
-        `${englishQuery} "updated to" "upgraded to" user experience review`,
-        `${englishQuery} performance battery life speed issues complaints`,
-        `${englishQuery} "worth updating" "should I update" recommendations`
-    ];
+    console.log(`🚀 Starting enhanced multi-site search for: "${englishQuery}"`);
     
-    const model = extractModelFromQuery(englishQuery);
-    if (!model) {
-        console.warn("Could not extract a specific model from the query for filtering. Results may be less focused.");
-    }
-
-    console.log(`🚀 Initiating enhanced paginated search for up to 100 results with ${searchQueries.length} different search strategies...`);
-
-    // יצירת חיפושים מקבילים - עד 100 תוצאות סה"כ
-    const allSearchPromises = [];
-    
-    for (let i = 0; i < searchQueries.length; i++) {
-        const query = searchQueries[i];
-        // עבור כל שאילתה, נבצע 2 חיפושים של 10 תוצאות (20 לכל שאילתה)
-        // סה"כ: 6 שאילתות * 20 תוצאות = 120, אבל נגביל ל-100
-        for (let page = 0; page < 2; page++) {
-            allSearchPromises.push(
-                axios.get(googleApiUrl, {
-                    params: { 
-                        key: GOOGLE_API_KEY, 
-                        cx: GOOGLE_CSE_ID, 
-                        q: query, 
-                        num: 10, 
-                        start: (page * 10) + 1, 
-                        dateRestrict: 'm6', // הרחבה ל-6 חודשים לכיסוי טוב יותר
-                        lr: 'lang_en' 
-                    }
-                }).catch(error => {
-                    console.warn(`Search failed for query: ${query}, page: ${page + 1}`, error.message);
-                    return { data: { items: [] } };
-                })
-            );
-        }
-    }
-
     try {
-        const responses = await Promise.all(allSearchPromises);
-        let allResults = [];
-        let uniqueLinks = new Set(); // למניעת כפילויות
+        // שימוש בחיפוש היברידי חדש
+        const allResults = await hybridSearch(englishQuery);
         
-        responses.forEach((response, index) => {
-            if (response.data.items) {
-                response.data.items.forEach(item => {
-                    // הוספת תוצאה רק אם הקישור לא קיים כבר
-                    if (!uniqueLinks.has(item.link)) {
-                        uniqueLinks.add(item.link);
-                        allResults.push({
-                            ...item,
-                            queryIndex: index // לזיהוי מאיזה חיפוש הגיעה התוצאה
-                        });
-                    }
-                });
-            }
-        });
-
-        console.log(`✅ Collected ${allResults.length} unique results from Google across ${searchQueries.length} search strategies.`);
-
+        const model = extractModelFromQuery(englishQuery);
+        
         if (!model) {
+            // אם אין מודל ספציפי, החזר את כל התוצאות
             return allResults
-                .slice(0, 100) // הגבלה ל-100 תוצאות
+                .slice(0, 100) // שמירה על 100 תוצאות כמו בקוד המקורי
                 .map(item => ({ 
                     title: item.title, 
                     link: item.link, 
                     snippet: item.snippet,
-                    queryType: searchQueries[item.queryIndex] || 'unknown'
+                    sourceSite: item.sourceSite || 'unknown'
                 }));
         }
 
-        // סינון מתקדם - חיפוש המודל בכותרת, בקטע או בקישור
+        // סינון לפי מודל ספציפי
         const filteredResults = allResults.filter(item => {
             const titleMatch = item.title && item.title.toLowerCase().includes(model);
             const snippetMatch = item.snippet && item.snippet.toLowerCase().includes(model);
@@ -110,9 +197,9 @@ async function searchGoogle(userQuery) {
             return titleMatch || snippetMatch || linkMatch;
         });
 
-        console.log(`🔍 Filtered down to ${filteredResults.length} results specifically mentioning "${model}" in title, snippet, or URL.`);
+        console.log(`🔍 Filtered to ${filteredResults.length} results for model "${model}"`);
 
-        // מיון התוצאות לפי רלוונטיות (תוצאות עם המודל בכותרת מקבלות עדיפות)
+        // מיון לפי רלוונטיות
         const sortedResults = filteredResults.sort((a, b) => {
             const aInTitle = a.title && a.title.toLowerCase().includes(model) ? 1 : 0;
             const bInTitle = b.title && b.title.toLowerCase().includes(model) ? 1 : 0;
@@ -120,17 +207,17 @@ async function searchGoogle(userQuery) {
         });
 
         return sortedResults
-            .slice(0, 100) // הגבלה ל-100 תוצאות הטובות ביותר
+            .slice(0, 100) // שמירה על 100 תוצאות כמו בקוד המקורי
             .map(item => ({ 
                 title: item.title, 
                 link: item.link, 
                 snippet: item.snippet,
-                queryType: searchQueries[item.queryIndex] || 'unknown'
+                sourceSite: item.sourceSite || 'unknown'
             }));
 
     } catch (error) {
         const errorDetails = error.response ? JSON.stringify(error.response.data, null, 2) : error.message;
-        console.error('❌ Error during enhanced paginated Google Search:', errorDetails);
+        console.error('❌ Error during enhanced multi-site search:', errorDetails);
         return [];
     }
 }

--- a/test-google-api.js
+++ b/test-google-api.js
@@ -7,13 +7,17 @@ const https = require('https');
 console.log('🔍 === Google Search API Test ===');
 console.log(`📅 Timestamp: ${new Date().toISOString()}`);
 
-// בדיקת משתני סביבה
-const apiKey = process.env.GOOGLE_SEARCH_API_KEY;
-const searchEngineId = process.env.GOOGLE_SEARCH_ENGINE_ID;
+// בדיקת משתני סביבה - גם החדשים וגם הישנים
+const apiKey = process.env.GOOGLE_SEARCH_API_KEY || process.env.GOOGLE_API_KEY;
+const searchEngineId = process.env.GOOGLE_SEARCH_ENGINE_ID || process.env.GOOGLE_CSE_ID;
 
 console.log('\n🔑 === Environment Variables ===');
-console.log(`GOOGLE_SEARCH_API_KEY: ${apiKey ? `✅ EXISTS (${apiKey.substring(0, 15)}...)` : '❌ MISSING'}`);
-console.log(`GOOGLE_SEARCH_ENGINE_ID: ${searchEngineId ? `✅ EXISTS (${searchEngineId})` : '❌ MISSING'}`);
+console.log(`GOOGLE_SEARCH_API_KEY: ${process.env.GOOGLE_SEARCH_API_KEY ? `✅ EXISTS (${process.env.GOOGLE_SEARCH_API_KEY.substring(0, 15)}...)` : '❌ MISSING'}`);
+console.log(`GOOGLE_SEARCH_ENGINE_ID: ${process.env.GOOGLE_SEARCH_ENGINE_ID ? `✅ EXISTS (${process.env.GOOGLE_SEARCH_ENGINE_ID})` : '❌ MISSING'}`);
+console.log(`GOOGLE_API_KEY (legacy): ${process.env.GOOGLE_API_KEY ? `✅ EXISTS (${process.env.GOOGLE_API_KEY.substring(0, 15)}...)` : '❌ MISSING'}`);
+console.log(`GOOGLE_CSE_ID (legacy): ${process.env.GOOGLE_CSE_ID ? `✅ EXISTS (${process.env.GOOGLE_CSE_ID})` : '❌ MISSING'}`);
+console.log(`Using API Key: ${apiKey ? `✅ ${apiKey.substring(0, 15)}...` : '❌ NONE'}`);
+console.log(`Using CSE ID: ${searchEngineId ? `✅ ${searchEngineId}` : '❌ NONE'}`);
 
 if (!apiKey || !searchEngineId) {
   console.log('\n❌ Cannot test API - missing required environment variables');
@@ -35,7 +39,7 @@ console.log('\n🚀 === Testing Google Search API ===');
 
 // בניית URL לבדיקה
 const testQuery = 'Android update';
-const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${searchEngineId}&q=${encodeURIComponent(testQuery)}&num=1`;
+const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${searchEngineId}&q=${encodeURIComponent(testQuery)}&num=3`;
 
 console.log(`🔍 Test query: "${testQuery}"`);
 console.log(`🌐 API URL: ${url.replace(apiKey, 'API_KEY_HIDDEN')}`);
@@ -68,10 +72,28 @@ https.get(url, (res) => {
         console.log(`Search time: ${jsonData.searchInformation?.searchTime || 'unknown'}s`);
         
         if (jsonData.items && jsonData.items.length > 0) {
-          console.log('\n📋 First result:');
-          console.log(`Title: ${jsonData.items[0].title}`);
-          console.log(`Link: ${jsonData.items[0].link}`);
-          console.log(`Snippet: ${jsonData.items[0].snippet?.substring(0, 100)}...`);
+          console.log('\n📋 Search Results:');
+          jsonData.items.forEach((item, index) => {
+            console.log(`\n${index + 1}. ${item.title}`);
+            console.log(`   URL: ${item.link}`);
+            console.log(`   Snippet: ${item.snippet?.substring(0, 100)}...`);
+            
+            // בדיקה מאיזה אתר הגיעה התוצאה
+            const domain = new URL(item.link).hostname;
+            console.log(`   Domain: ${domain}`);
+          });
+          
+          // סטטיסטיקה של דומיינים
+          const domains = {};
+          jsonData.items.forEach(item => {
+            const domain = new URL(item.link).hostname;
+            domains[domain] = (domains[domain] || 0) + 1;
+          });
+          
+          console.log('\n📊 === Domain Distribution ===');
+          Object.entries(domains).forEach(([domain, count]) => {
+            console.log(`   ${domain}: ${count} results`);
+          });
         }
         
         console.log('\n🎉 Google Search API is working correctly!');

--- a/test-site-search.js
+++ b/test-site-search.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+// סקריפט בדיקת חיפוש באתרים ספציפיים
+require('dotenv').config();
+const https = require('https');
+
+console.log('🔍 === Site-Specific Search Test ===');
+console.log(`📅 Timestamp: ${new Date().toISOString()}`);
+
+// בדיקת משתני סביבה
+const apiKey = process.env.GOOGLE_SEARCH_API_KEY || process.env.GOOGLE_API_KEY;
+const searchEngineId = process.env.GOOGLE_SEARCH_ENGINE_ID || process.env.GOOGLE_CSE_ID;
+
+console.log('\n🔑 === Environment Variables ===');
+console.log(`API Key: ${apiKey ? `✅ EXISTS (${apiKey.substring(0, 15)}...)` : '❌ MISSING'}`);
+console.log(`CSE ID: ${searchEngineId ? `✅ EXISTS (${searchEngineId})` : '❌ MISSING'}`);
+
+if (!apiKey || !searchEngineId) {
+  console.log('\n❌ Cannot test - missing environment variables');
+  process.exit(1);
+}
+
+// האתרים לבדיקה
+const TARGET_SITES = [
+    'reddit.com',
+    'xda-developers.com', 
+    'androidcentral.com',
+    'androidpolice.com',
+    '9to5google.com',
+    'support.google.com'
+];
+
+const testQuery = 'Android 14 update';
+
+console.log(`\n🚀 === Testing Search for: "${testQuery}" ===`);
+console.log(`🎯 Testing ${TARGET_SITES.length} sites...`);
+
+// פונקציה לבדיקת אתר בודד
+function testSiteSearch(site) {
+    return new Promise((resolve) => {
+        const siteQuery = `${testQuery} site:${site}`;
+        const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${searchEngineId}&q=${encodeURIComponent(siteQuery)}&num=3`;
+        
+        console.log(`\n🔍 Testing ${site}...`);
+        console.log(`📝 Query: "${siteQuery}"`);
+        
+        const startTime = Date.now();
+        
+        https.get(url, (res) => {
+            const responseTime = Date.now() - startTime;
+            let data = '';
+            
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+            
+            res.on('end', () => {
+                try {
+                    const jsonData = JSON.parse(data);
+                    
+                    if (res.statusCode === 200) {
+                        const items = jsonData.items || [];
+                        console.log(`✅ ${site}: ${items.length} results (${responseTime}ms)`);
+                        
+                        if (items.length > 0) {
+                            items.forEach((item, index) => {
+                                const domain = new URL(item.link).hostname;
+                                console.log(`   ${index + 1}. ${item.title.substring(0, 60)}...`);
+                                console.log(`      ${item.link}`);
+                                console.log(`      Domain: ${domain}`);
+                                
+                                // בדיקה אם התוצאה באמת מהאתר הנכון
+                                if (!domain.includes(site.replace('.com', ''))) {
+                                    console.log(`      ⚠️  WARNING: Result not from expected site!`);
+                                }
+                            });
+                        } else {
+                            console.log(`   ❌ No results found for ${site}`);
+                        }
+                        
+                        resolve({
+                            site,
+                            success: true,
+                            count: items.length,
+                            responseTime,
+                            results: items
+                        });
+                        
+                    } else {
+                        console.log(`❌ ${site}: Error ${res.statusCode}`);
+                        if (jsonData.error) {
+                            console.log(`   Error: ${jsonData.error.message}`);
+                        }
+                        
+                        resolve({
+                            site,
+                            success: false,
+                            error: jsonData.error?.message || `HTTP ${res.statusCode}`,
+                            responseTime
+                        });
+                    }
+                    
+                } catch (parseError) {
+                    console.log(`❌ ${site}: Parse error`);
+                    resolve({
+                        site,
+                        success: false,
+                        error: 'Parse error',
+                        responseTime
+                    });
+                }
+            });
+            
+        }).on('error', (err) => {
+            console.log(`❌ ${site}: Network error - ${err.message}`);
+            resolve({
+                site,
+                success: false,
+                error: err.message,
+                responseTime: Date.now() - startTime
+            });
+        });
+    });
+}
+
+// בדיקת כל האתרים
+async function runTests() {
+    const results = [];
+    
+    for (const site of TARGET_SITES) {
+        const result = await testSiteSearch(site);
+        results.push(result);
+        
+        // המתנה קצרה בין בקשות
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    
+    // סיכום התוצאות
+    console.log('\n📊 === SUMMARY ===');
+    
+    const successful = results.filter(r => r.success);
+    const failed = results.filter(r => !r.success);
+    const totalResults = successful.reduce((sum, r) => sum + r.count, 0);
+    
+    console.log(`✅ Successful searches: ${successful.length}/${TARGET_SITES.length}`);
+    console.log(`❌ Failed searches: ${failed.length}/${TARGET_SITES.length}`);
+    console.log(`📈 Total results found: ${totalResults}`);
+    
+    if (successful.length > 0) {
+        console.log('\n📋 Results by site:');
+        successful.forEach(r => {
+            console.log(`   ${r.site}: ${r.count} results`);
+        });
+        
+        const avgResponseTime = successful.reduce((sum, r) => sum + r.responseTime, 0) / successful.length;
+        console.log(`\n⏱️  Average response time: ${Math.round(avgResponseTime)}ms`);
+    }
+    
+    if (failed.length > 0) {
+        console.log('\n❌ Failed sites:');
+        failed.forEach(r => {
+            console.log(`   ${r.site}: ${r.error}`);
+        });
+    }
+    
+    // המלצות
+    console.log('\n💡 === RECOMMENDATIONS ===');
+    
+    if (totalResults === 0) {
+        console.log('🚨 NO RESULTS FOUND AT ALL!');
+        console.log('   - Check your Custom Search Engine configuration');
+        console.log('   - Verify API key and CSE ID are correct');
+        console.log('   - Make sure sites are properly added to CSE');
+    } else if (successful.length < TARGET_SITES.length / 2) {
+        console.log('⚠️  Many sites returning no results');
+        console.log('   - Check if sites are properly configured in CSE');
+        console.log('   - Verify site URLs are correct (no www. prefix)');
+    } else if (successful.length === 1 && successful[0].site === 'reddit.com') {
+        console.log('🎯 FOUND THE PROBLEM!');
+        console.log('   - Only Reddit is returning results');
+        console.log('   - Your CSE is probably configured for Reddit only');
+        console.log('   - Follow the GOOGLE_CSE_FIX_GUIDE.md to fix this');
+    } else {
+        console.log('✅ Search is working across multiple sites!');
+        console.log('   - Your CSE configuration looks good');
+    }
+}
+
+runTests().catch(console.error);


### PR DESCRIPTION
Reimplement multi-site search logic to ensure results from all specified domains and improve robustness.

The previous setup relied heavily on Custom Search Engine (CSE) configuration, which led to results only from Reddit. This PR introduces direct `site:` operator usage for targeted searches, a balanced search across all specified domains, and a general search fallback to ensure comprehensive results, mitigating potential CSE misconfigurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-c877d083-72c4-4a63-901f-0212166207d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c877d083-72c4-4a63-901f-0212166207d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>